### PR TITLE
feat: add meaningful error when bank and report output is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Please create an issue and explain the problem, and your approach to solve it, a
 ## Supported banks
 
 
-| Bank                  | Country | Swift    | Steps                                     |
-| --------------------- | ------- | -------- | ----------------------------------------- |
-| Federal Bank          | IN      | FDRLINBB | Download the statement file in xls format |
-| State Bank of India   | IN      | SBININBB | Download the statement file in csv format |
-| Kotak Bank            | IN      | KKBKINBB | Download the statement file in csv format |
-| Emirates Islamic Bank | AE      | MEBLAEAD | Download the statement file in excel format. Open it on excel and save again as Excel 97 format                                          |
+| Bank                  | Country | Swift    | Steps                                                                                           |
+|-----------------------|---------|----------|-------------------------------------------------------------------------------------------------|
+| Federal Bank          | IN      | FDRLINBB | Download the statement file in xls format                                                       |
+| State Bank of India   | IN      | SBININBB | Download the statement file in csv format                                                       |
+| Kotak Bank            | IN      | KKBKINBB | Download the statement file in csv format                                                       |
+| Emirates Islamic Bank | AE      | MEBLAEAD | Download the statement file in excel format. Open it on excel and save again as Excel 97 format |

--- a/app.py
+++ b/app.py
@@ -14,11 +14,11 @@ def setup_logger():
                         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 
-def main(args):
+def main(cli_args):
     setup_logger()
     p = Processor()
     p.initialize()
-    p.process(args.source, args.destination, args.output_format, args.output_file)
+    p.process(cli_args.source, cli_args.destination, cli_args.output_format, cli_args.output_file)
     p.finalize()
 
 

--- a/bankii/base/output.py
+++ b/bankii/base/output.py
@@ -70,6 +70,12 @@ class Statement:
     def __init__(self):
         self.statements = []
 
+    def len(self):
+        return len(self.statements)
+
+    def is_empty(self):
+        return len(self.statements) == 0
+
     def add_statement_line(self, **statement_line_args):
         statement_line = StatementLine(**statement_line_args)
         self.statements.append(statement_line)

--- a/bankii/processor.py
+++ b/bankii/processor.py
@@ -152,6 +152,9 @@ class Processor:
             report_data = bank_report_itr[1]
             ext = report_data.get('ext')
             bank_class: typing.Type[BaseBank] = bank_report_itr[2]
+            if bank_class is None:
+                logger.warning('Unsupported bank report and file extension: {}'.format(report_data))
+                continue
             parser_options = bank_class.parser_options
             reader = self.rm.add_reader(file_path, ext, parser_options)
 
@@ -175,13 +178,16 @@ class Processor:
                         'debit_amount': debit_amount, 'balance_amount': balance_amount,
                         'statement_reference': statement_reference, 'file_id': file_id
                     })
+        if statment.is_empty():
+            logger.warning('No statement data found to output')
+            return
         statment.sort_statements()
-        #logger.debug('Output: \n: {}'.format('\n'.join([str(x) for x in statment.to_csv()])))
+        # logger.debug('Output: \n: {}'.format('\n'.join([str(x) for x in statment.to_csv()])))
         # Output data
         # TODO: Better manage the output; CReate folders first
         if not output_file.endswith(output_format):
             output_file = '{}.{}'.format(output_file, output_format)
-        if output_format.lower() == 'csv':
+        if output_format.lower() == 'csv' :
             writer = self.wm.get_writer(output_format.lower())
             writer_inst = writer(destination_folder, output_file)
             writer_inst.write_file(statment.to_csv())


### PR DESCRIPTION
When we choose a bank/swift, and if the report format is not supported. For eg: instead of 
```
    report_file_ext = 'xls'
    country = 'IN'
    name = 'Federal Bank'
    swift = 'FDRLINBB'
    description = 'Federal Bank class'
```
if the report given is 'csv' we were getting the below error
```
Traceback (most recent call last):
  File "app.py", line 40, in <module>
    main(args)
  File "app.py", line 21, in main
    p.process(cli_args.source, cli_args.destination, cli_args.output_format, cli_args.output_file)
  File "/Users/jasimmk/Project/bankii/bankii/processor.py", line 155, in process
    parser_options = bank_class.parser_options
```